### PR TITLE
First changes for Python 3

### DIFF
--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -21,12 +21,24 @@ file into a screed database.
 Conversion between sequence file types is provided in the ToFastq and
 ToFasta functions
 """
-from openscreed import ScreedDB, open
-from conversion import ToFastq
-from conversion import ToFasta
-from createscreed import create_db
-from seqparse import read_fastq_sequences
-from seqparse import read_fasta_sequences
-from dna import rc
+
+# conditional import for Python 2 / Python 3
+import sys
+if sys.version_info[0] == 2:
+    from openscreed import ScreedDB, open
+    from conversion import ToFastq
+    from conversion import ToFasta
+    from createscreed import create_db
+    from seqparse import read_fastq_sequences
+    from seqparse import read_fasta_sequences
+    from dna import rc
+else:
+    from .openscreed import ScreedDB, open
+    from .conversion import ToFastq
+    from .conversion import ToFasta
+    from .createscreed import create_db
+    from .seqparse import read_fastq_sequences
+    from .seqparse import read_fasta_sequences
+    from .dna import rc
 
 __version__ = '0.7'

--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -24,21 +24,13 @@ ToFasta functions
 
 # conditional import for Python 2 / Python 3
 import sys
-if sys.version_info[0] == 2:
-    from openscreed import ScreedDB, open
-    from conversion import ToFastq
-    from conversion import ToFasta
-    from createscreed import create_db
-    from seqparse import read_fastq_sequences
-    from seqparse import read_fasta_sequences
-    from dna import rc
-else:
-    from .openscreed import ScreedDB, open
-    from .conversion import ToFastq
-    from .conversion import ToFasta
-    from .createscreed import create_db
-    from .seqparse import read_fastq_sequences
-    from .seqparse import read_fasta_sequences
-    from .dna import rc
+from __future__ import absolute_import
+from .openscreed import ScreedDB, open
+from .conversion import ToFastq
+from .conversion import ToFasta
+from .createscreed import create_db
+from .seqparse import read_fastq_sequences
+from .seqparse import read_fasta_sequences
+from .dna import rc
 
-__version__ = '0.7'
+__version__ = '0.7.1'

--- a/screed/conversion.py
+++ b/screed/conversion.py
@@ -1,10 +1,8 @@
 # Copyright (c) 2008-2010, Michigan State University
 
 import sys
-if sys.version_info[0] < 3:
-    from openscreed import ScreedDB
-else:
-    from .openscreed import ScreedDB
+from __future__ import absolute_import
+from .openscreed import ScreedDB
 
 _MAXLINELEN = 80
 _null_accuracy = '\"' # ASCII 34, e.g 75% chance of incorrect read

--- a/screed/conversion.py
+++ b/screed/conversion.py
@@ -1,6 +1,10 @@
 # Copyright (c) 2008-2010, Michigan State University
 
-from openscreed import ScreedDB
+import sys
+if sys.version_info[0] < 3:
+    from openscreed import ScreedDB
+else:
+    from .openscreed import ScreedDB
 
 _MAXLINELEN = 80
 _null_accuracy = '\"' # ASCII 34, e.g 75% chance of incorrect read

--- a/screed/createscreed.py
+++ b/screed/createscreed.py
@@ -1,8 +1,6 @@
 import sys
-if sys.version_info[0] < 3:
-    import DBConstants
-else:
-    from . import DBConstants
+from __future__ import absolute_import
+from . import DBConstants
 import os
 import sqlite3
 import itertools

--- a/screed/createscreed.py
+++ b/screed/createscreed.py
@@ -1,4 +1,8 @@
-import DBConstants
+import sys
+if sys.version_info[0] < 3:
+    import DBConstants
+else:
+    from . import DBConstants
 import os
 import sqlite3
 import itertools

--- a/screed/dna.py
+++ b/screed/dna.py
@@ -28,7 +28,11 @@ def reverse_complement(s):
 
 rc = reverse_complement                 # alias 'rc' to 'reverse_complement'
 
-__complementTranslation = string.maketrans('ACTG', 'TGAC')
+import sys
+if sys.version_info[0] < 3:
+    __complementTranslation = string.maketrans('ACTG', 'TGAC')
+else:
+    __complementTranslation = str.maketrans('ACTG', 'TGAC')
 
 def complement(s):
     """

--- a/screed/dump_to_fasta.py
+++ b/screed/dump_to_fasta.py
@@ -8,14 +8,14 @@ import sys, os
 # Shell interface to the ToFasta screed conversion function
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print "Usage: %s <dbfilename> <outputfilename>" % sys.argv[0]
+        print("Usage: %s <dbfilename> <outputfilename>" % sys.argv[0])
         exit(1)
 
     dbFile = sys.argv[1]
     outputFile = sys.argv[2]
 
     if not os.path.isfile(dbFile):
-        print "No such file: %s" % dbFile
+        print("No such file: %s" % dbFile)
         exit(1)
     if os.path.isfile(outputFile):
         os.unlink(outputFile)

--- a/screed/dump_to_fastq.py
+++ b/screed/dump_to_fastq.py
@@ -8,14 +8,14 @@ import sys, os
 # Shell interface to the ToFastq screed conversion function
 if __name__ == '__main__':
     if len(sys.argv) != 3:
-        print "Usage: %s <dbfilename> <outputfilename>" % sys.argv[0]
+        print("Usage: %s <dbfilename> <outputfilename>" % sys.argv[0])
         exit(1)
 
     dbFile = sys.argv[1]
     outputFile = sys.argv[2]
 
     if not os.path.isfile(dbFile):
-        print "No such file: %s" % dbFile
+        print("No such file: %s" % dbFile)
         exit(1)
     if os.path.isfile(outputFile):
         os.unlink(outputFile)

--- a/screed/fadbm.py
+++ b/screed/fadbm.py
@@ -16,5 +16,5 @@ if __name__ == "__main__":
     filename = sys.argv[1]
     read_fasta_sequences(filename)
     
-    print "Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension)
+    print("Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension))
 

--- a/screed/fasta.py
+++ b/screed/fasta.py
@@ -1,10 +1,7 @@
 import sys
-if sys.version_info[0] < 3:
-    import DBConstants
-    from screedRecord import _screed_record_dict
-else:
-    from . import DBConstants
-    from .screedRecord import _screed_record_dict
+from __future__ import absolute_import
+from . import DBConstants
+from .screedRecord import _screed_record_dict
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('description', DBConstants._STANDARD_TEXT),

--- a/screed/fasta.py
+++ b/screed/fasta.py
@@ -1,5 +1,10 @@
-import DBConstants
-from screedRecord import _screed_record_dict
+import sys
+if sys.version_info[0] < 3:
+    import DBConstants
+    from screedRecord import _screed_record_dict
+else:
+    from . import DBConstants
+    from .screedRecord import _screed_record_dict
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('description', DBConstants._STANDARD_TEXT),

--- a/screed/fastq.py
+++ b/screed/fastq.py
@@ -1,10 +1,7 @@
 import sys
-if sys.version_info[0] < 3:
-    import DBConstants
-    from screedRecord import _screed_record_dict
-else:
-    from . import DBConstants
-    from .screedRecord import _screed_record_dict
+form __future__ import absolute_import
+from . import DBConstants
+from .screedRecord import _screed_record_dict
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('annotations', DBConstants._STANDARD_TEXT),

--- a/screed/fastq.py
+++ b/screed/fastq.py
@@ -1,5 +1,10 @@
-import DBConstants
-from screedRecord import _screed_record_dict
+import sys
+if sys.version_info[0] < 3:
+    import DBConstants
+    from screedRecord import _screed_record_dict
+else:
+    from . import DBConstants
+    from .screedRecord import _screed_record_dict
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('annotations', DBConstants._STANDARD_TEXT),

--- a/screed/fqdbm.py
+++ b/screed/fqdbm.py
@@ -16,5 +16,5 @@ if __name__ == "__main__":
     filename = sys.argv[1]
     read_fastq_sequences(filename)
 
-    print "Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension)
+    print("Database saved in %s%s" % (sys.argv[1], DBConstants.fileExtension))
     exit(0)

--- a/screed/hava.py
+++ b/screed/hava.py
@@ -1,4 +1,8 @@
-import DBConstants
+import sys
+if sys.version_info[0] < 3:
+    import DBConstants
+else:
+    from . import DBConstants
 
 FieldTypes = (('hava', DBConstants._INDEXED_TEXT_KEY),
               ('quarzk', DBConstants._STANDARD_TEXT),

--- a/screed/hava.py
+++ b/screed/hava.py
@@ -1,8 +1,6 @@
 import sys
-if sys.version_info[0] < 3:
-    import DBConstants
-else:
-    from . import DBConstants
+from __future__ import absolute_import
+from . import DBConstants
 
 FieldTypes = (('hava', DBConstants._INDEXED_TEXT_KEY),
               ('quarzk', DBConstants._STANDARD_TEXT),

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -14,16 +14,11 @@ import sqlite3
 import gzip
 import bz2
 
-if sys.version_info[0] < 3:
-    import DBConstants
-    import screedRecord
-    from fastq import fastq_iter
-    from fasta import fasta_iter
-else:
-    from . import DBConstants
-    from . import screedRecord
-    from .fastq import fastq_iter
-    from .fasta import fasta_iter
+from __future__ import absolute_import
+from . import DBConstants
+from . import screedRecord
+from .fastq import fastq_iter
+from .fasta import fasta_iter
 
 def open(filename, *args, **kwargs):
     """

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -1,15 +1,29 @@
 import os
 import types
-import UserDict
+# compatibility with antique versions of Python,
+# although I suspect that the rest in not compatible
+# with Python < 2.6 anyway...
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] < 6:
+    import UserDict
+    MutableMapping = UserDict.DictMixin
+else:
+    from collections import MutableMapping
 import types
 import sqlite3
 import gzip
 import bz2
 
-import DBConstants
-import screedRecord
-from fastq import fastq_iter
-from fasta import fasta_iter
+if sys.version_info[0] < 3:
+    import DBConstants
+    import screedRecord
+    from fastq import fastq_iter
+    from fasta import fasta_iter
+else:
+    from . import DBConstants
+    from . import screedRecord
+    from .fastq import fastq_iter
+    from .fasta import fasta_iter
 
 def open(filename, *args, **kwargs):
     """
@@ -22,7 +36,7 @@ def open(filename, *args, **kwargs):
     elif filename.endswith('.bz2'):
         fp = bz2.BZ2File(filename)
     else:
-        fp = file(filename)
+        fp = __builtins__['open'](filename, mode="rb")
 
     line = fp.readline()
 
@@ -30,9 +44,9 @@ def open(filename, *args, **kwargs):
         return []
 
     iter_fn = None
-    if line.startswith('>'):
+    if line.startswith(b'>'):
         iter_fn = fasta_iter
-    elif line.startswith('@'):
+    elif line.startswith(b'@'):
         iter_fn = fastq_iter
 
     if iter_fn is None:
@@ -41,7 +55,7 @@ def open(filename, *args, **kwargs):
     fp.seek(0)
     return iter_fn(fp, *args, **kwargs)
 
-class ScreedDB(object, UserDict.DictMixin):
+class ScreedDB(MutableMapping):
     """
     Core on-disk dictionary interface for reading screed databases. Accepts a
     path string to a screed database

--- a/screed/pygr_api.py
+++ b/screed/pygr_api.py
@@ -156,8 +156,8 @@ if __name__ == '__main__':
 
     db = ScreedSequenceDB(filename)
     for k in db:
-        print k, repr(db[k]), db[k].name
+        print(k, repr(db[k]), db[k].name)
 
     db = ScreedSequenceDB_ByIndex(filename)
     for k in db:
-        print k, repr(db[k]), db[k].name
+        print(k, repr(db[k]), db[k].name)

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -8,10 +8,8 @@ if sys.version_info[0] == 2 and sys.version_info[1] < 6:
 else:
     from collections import MutableMapping
 import types
-if sys.version_info[0] < 3:
-    import DBConstants
-else:
-    from . import DBConstants
+from __future__ import absolute_import
+from . import DBConstants
 
 class _screed_record_dict(MutableMapping):
     """

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -1,8 +1,19 @@
-import UserDict
+# compatibility with antique versions of Python,
+# although I suspect that the rest in not compatible
+# with Python < 2.6 anyway...
+import sys
+if sys.version_info[0] == 2 and sys.version_info[1] < 6:
+    import UserDict
+    MutableMapping = UserDict.DictMixin
+else:
+    from collections import MutableMapping
 import types
-import DBConstants
+if sys.version_info[0] < 3:
+    import DBConstants
+else:
+    from . import DBConstants
 
-class _screed_record_dict(UserDict.DictMixin):
+class _screed_record_dict(MutableMapping):
     """
     Simple dict-like record interface with bag behavior.
     """
@@ -19,7 +30,7 @@ class _screed_record_dict(UserDict.DictMixin):
         try:
             return self.d[name]
         except KeyError:
-            raise AttributeError, name
+            raise AttributeError(name)
 
     def keys(self):
         return self.d.keys()

--- a/screed/seqparse.py
+++ b/screed/seqparse.py
@@ -7,19 +7,12 @@ parser is included for API reference
 """
 
 import os
-import sys
-if sys.version_info[0] < 3:
-    from createscreed import create_db
-    from openscreed import ScreedDB
-    import fastq
-    import fasta
-    import hava
-else:
-    from .createscreed import create_db
-    from .openscreed import ScreedDB
-    from . import fastq
-    from . import fasta
-    from . import hava
+from __future__ import absolute_import
+from .createscreed import create_db
+from .openscreed import ScreedDB
+from . import fastq
+from . import fasta
+from . import hava
 
 # [AN] these functions look strangely similar
 def read_fastq_sequences(filename):

--- a/screed/seqparse.py
+++ b/screed/seqparse.py
@@ -7,18 +7,25 @@ parser is included for API reference
 """
 
 import os
-from createscreed import create_db
-from openscreed import ScreedDB
-import fastq
-import fasta
-import hava
+import sys
+if sys.version_info[0] < 3:
+    from createscreed import create_db
+    from openscreed import ScreedDB
+    import fastq
+    import fasta
+    import hava
+else:
+    from .createscreed import create_db
+    from .openscreed import ScreedDB
+    from . import fastq
+    from . import fasta
+    from . import hava
 
 # [AN] these functions look strangely similar
 def read_fastq_sequences(filename):
     """
     Function to parse text from the given FASTQ file into a screed database
     """
-    import openscreed
     
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)
@@ -32,7 +39,6 @@ def read_fasta_sequences(filename):
     """
     Function to parse text from the given FASTA file into a screed database
     """
-    import openscreed
     
     # Will raise an exception if the file doesn't exist
     iterfunc = openscreed.open(filename)

--- a/screed/tests/havaGen.py
+++ b/screed/tests/havaGen.py
@@ -83,7 +83,7 @@ def createHavaFiles(filename, size, divisions):
 
 if __name__ == '__main__':
     if len(sys.argv) != 4:
-        print "Usage: <filename> <size> <divisions>"
+        print("Usage: <filename> <size> <divisions>")
         exit(1)
 
     filename = sys.argv[1]

--- a/screed/tests/test_fasta.py
+++ b/screed/tests/test_fasta.py
@@ -1,7 +1,11 @@
+import os
 import screed
 from screed.DBConstants import fileExtension
-import os
-from cStringIO import StringIO
+import sys
+if sys.version_info[0] < 3:
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
 def test_new_record():
     # test for a bug where the record dict was not reset after each

--- a/screed/tests/test_fastq.py
+++ b/screed/tests/test_fastq.py
@@ -1,7 +1,11 @@
 import screed
 from screed.DBConstants import fileExtension
 import os
-from cStringIO import StringIO
+import sys
+if sys.version_info[0] < 3:
+    from cStringIO import StringIO
+else:
+    from io import StringIO
 
 def test_new_record():
     # test for a bug where the record dict was not reset after each

--- a/screed/tests/test_pygr_api.py
+++ b/screed/tests/test_pygr_api.py
@@ -6,7 +6,7 @@ try:
     import pygr
 except ImportError:
     import nose
-    raise nose.SkipTest, "pygr is required for these tests"
+    raise nose.SkipTest("pygr is required for these tests")
 
 import screed
 from screed.DBConstants import fileExtension

--- a/screed/tests/test_shell.py
+++ b/screed/tests/test_shell.py
@@ -4,12 +4,9 @@ import screed
 from screed.DBConstants import fileExtension
 
 import sys
-if sys.version_info[0] < 3:
-    import test_fasta
-    import test_fastq
-else:
-    from . import test_fasta
-    from . import test_fastq
+from __future__ import absolute_import
+from . import test_fasta
+from . import test_fastq
 
 class Test_fa_shell(test_fasta.Test_fasta):
     """

--- a/screed/tests/test_shell.py
+++ b/screed/tests/test_shell.py
@@ -1,9 +1,15 @@
-import test_fasta
-import test_fastq
 import os
 import subprocess
 import screed
 from screed.DBConstants import fileExtension
+
+import sys
+if sys.version_info[0] < 3:
+    import test_fasta
+    import test_fastq
+else:
+    from . import test_fasta
+    from . import test_fastq
 
 class Test_fa_shell(test_fasta.Test_fasta):
     """

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 try:
     from setuptools import setup
 except ImportError:
-    print '(WARNING: importing distutils, not setuptools!)'
+    print('(WARNING: importing distutils, not setuptools!)')
     from distutils.core import setup
 
 setup(name='screed',


### PR DESCRIPTION
These were relatively quick and straightforward to make.
There is much more to be needed, and likely important revisions to make regarding the split between `str` and `bytes` (absent in older Python versions).