### PR TITLE
Fix a typo in screedRecord

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2015-03-06  Kevin Murray  <spam@kdmurray.id.au>
+
+   * screed/screedRecord.py: Fix a typo in a try: except: block.
+   s/AttributError/AttributeError/
+
 2015-02-23  Gabriel Pratt  <gpratt@ucsd.edu>
 
    * Fixed Issue 705 len(read) != len(read.sequence)

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -126,7 +126,7 @@ class _screed_attr(object):
 
         try:
             return self.__repr__() != str(given)
-        except AttributError:
+        except AttributeError:
             raise TypeError("Cannot compare to given type: %s" % type(given))
 
     def __str__(self):


### PR DESCRIPTION
This is a trivial patch. Was reading the code and noticed a typo in a try: except: block.

