### PR TITLE
renamed _screed_record_dict()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2015-04-09  Sarah Guermond  <sarah.guermond@gmail.com>
+
+   * screed/screedRecord.py: renamed _screed_record_dict() to Rename()
+   * screed/__init__.py: added import for Record
+   * screed/fasta.py: changed _screed_record_dict() to Rename()
+   * screed/fastq.py: changed _screed_record_dict() to Rename()
+
 2015-04-09  Jacob Fenton  <bocajnotnef@gmail.com>
    
    * doc/dev/release-checklist.txt: added "making final release" notes

--- a/screed/__init__.py
+++ b/screed/__init__.py
@@ -29,6 +29,7 @@ from createscreed import create_db
 from seqparse import read_fastq_sequences
 from seqparse import read_fasta_sequences
 from dna import rc
+from screedRecord import Record
 
 from _version import get_versions
 __version__ = get_versions()['version']

--- a/screed/fasta.py
+++ b/screed/fasta.py
@@ -1,5 +1,5 @@
 import DBConstants
-from screedRecord import _screed_record_dict, _Writer
+from screedRecord import Record, _Writer
 
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('description', DBConstants._STANDARD_TEXT),
@@ -15,7 +15,7 @@ def fasta_iter(handle, parse_description=True, line=None):
         line = handle.readline()
 
     while line:
-        data = _screed_record_dict()
+        data = Record()
 
         line = line.strip()
         if not line.startswith('>'):

--- a/screed/fastq.py
+++ b/screed/fastq.py
@@ -1,5 +1,5 @@
 import DBConstants
-from screedRecord import _screed_record_dict, _Writer
+from screedRecord import Record, _Writer
 FieldTypes = (('name', DBConstants._INDEXED_TEXT_KEY),
               ('annotations', DBConstants._STANDARD_TEXT),
               ('sequence', DBConstants._STANDARD_TEXT),
@@ -15,7 +15,7 @@ def fastq_iter(handle, line=None, parse_description=True):
         line = handle.readline()
     line = line.strip()
     while line:
-        data = _screed_record_dict()
+        data = Record()
 
         if not line.startswith('@'):
             raise IOError("Bad FASTQ format: no '@' at beginning of line")

--- a/screed/screedRecord.py
+++ b/screed/screedRecord.py
@@ -5,7 +5,7 @@ import gzip
 import bz2
 
 
-class _screed_record_dict(UserDict.DictMixin):
+class Record(UserDict.DictMixin):
 
     """
     Simple dict-like record interface with bag behavior.
@@ -181,7 +181,7 @@ def _buildRecord(fieldTuple, dbObj, rowName, queryBy):
         else:
             hackedResult.append((key, value))
 
-    return _screed_record_dict(hackedResult)
+    return Record(hackedResult)
 
 
 class _Writer(object):


### PR DESCRIPTION
Fixed issue ged-lab/khmer#767
- renamed _screed_record_dict() to Record()
- applied name change to fasta.py, fastq.py
- added import in screed __init__.py
- did not specify arguments as suggested since it did not add improvements
  - fasta.py takes in name, description, sequence
  - fastq.py takes in name, annotations, sequence, quality
  - screedRecord.py/_buildRecord does not take arguments

- [x] Is it mergeable?
- [x] Did it pass the tests?
- [x] If it introduces new functionality in scripts/ is it tested?
  Check for code coverage with `make clean diff-cover`
- [x] Is it well formatted? Look at `make pep8`, `make diff_pylint_report`,
  `make cppcheck`, and `make doc` output. Use `make format` and manual
  fixing as needed.
- [x] Did it change the command-line interface? Only additions are allowed
  without a major version increment. Changing file formats also requires a
  major version number increment.
- [ ] Is it documented in the ChangeLog?
  http://en.wikipedia.org/wiki/Changelog#Format
- [x] Was a spellchecker run on the source code and documentation after
  changes were made?