### PR TITLE
changed streaming test to fail for missing imports before starting threads

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,12 @@
 2015-04-15  Thomas Fenzl  <thomas.fenzl@gmx.net>
 
+   * screed/tests/screed_tst_utils.py: removed unnecessary import
+   * screed/tests/test_streaming.py: changed execution order to handle
+   missing import files better
+   * screed/openscreed.py: pylint-ified
+
+2015-04-15  Thomas Fenzl  <thomas.fenzl@gmx.net>
+
    * Makefile: added setup.py develop to test goal
    * screed/openscreed.py,screed/tests/test_open.py: added handling of '-'
 

--- a/screed/openscreed.py
+++ b/screed/openscreed.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2008-2015, Michigan State University
+"""Reader and writer for screed."""
 
 import os
 import types

--- a/screed/tests/screed_tst_utils.py
+++ b/screed/tests/screed_tst_utils.py
@@ -16,7 +16,6 @@ from cStringIO import StringIO
 import nose
 import sys
 import traceback
-import subprocess
 
 
 def get_test_data(filename):

--- a/screed/tests/test_streaming.py
+++ b/screed/tests/test_streaming.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2008-2015, Michigan State University
+
 import test_fasta
 import test_fastq
 import tempfile
@@ -25,6 +27,7 @@ def streamer(ifilename):
     # Get temp filenames, etc.
     in_dir = tempfile.mkdtemp(prefix="screedtest_")
     fifo = os.path.join(in_dir, 'fifo')
+    ifile = io.open(ifilename, 'rb')
 
     # make a fifo to simulate streaming
     os.mkfifo(fifo)
@@ -36,7 +39,6 @@ def streamer(ifilename):
     thread = threading.Thread(target=streamer_reader, args=[fifo, exception])
     thread.start()
 
-    ifile = io.open(ifilename, 'rb')
     fifofile = io.open(fifo, 'wb')
     # read binary to handle compressed files
     chunk = ifile.read(8192)


### PR DESCRIPTION
fixes https://github.com/ged-lab/khmer/issues/903

The thread was started before checking for the existence of the input file, which lead to hanging tests.